### PR TITLE
Enable the Push button when the RCheckin radio button is selected.

### DIFF
--- a/GitTfsDialog.Designer.cs
+++ b/GitTfsDialog.Designer.cs
@@ -238,6 +238,7 @@
             this.RCheckinRadioButton.TabStop = true;
             this.RCheckinRadioButton.Text = "Recursively Checkin changes to TFS";
             this.RCheckinRadioButton.UseVisualStyleBackColor = true;
+            this.RCheckinRadioButton.CheckedChanged += new System.EventHandler(this.PushOptionCheckedChanged);
             // 
             // ShelveRadioButton
             // 


### PR DESCRIPTION
The Push button is only enabled when the Checkin or Shelve radio buttons are selected
This patch enables this button for RCheckin as well.

Signed-off-by: Pat Thoyts patthoyts@users.sourceforge.net
